### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Jorge Villalobos
 maintainer=Jorge Villalobos <jorgemvc@gmail.com>
 sentence=Simple library for S4A EDU Robotic Controller.
 paragraph=Simple library for S4A EDU Robotic Controller.
-category=Motor Controller
+category=Device Control
 url=https://github.com/jorgemvc/S4ALib
 architectures=*


### PR DESCRIPTION
Use of invalid category caused the warning on every compilation:

WARNING: Category 'Motor Controller' in library S4ALib is not valid. Setting to 'Uncategorized'

List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format