### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,25 +7,25 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SA4Lib  KEYWORD1
+SA4Lib	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-forward  KEYWORD2
-backward KEYWORD2
-left KEYWORD2
-right KEYWORD2
-stop  KEYWORD2
-ledOn KEYWORD2
-ledOff  KEYWORD2
+forward	KEYWORD2
+backward	KEYWORD2
+left	KEYWORD2
+right	KEYWORD2
+stop	KEYWORD2
+ledOn	KEYWORD2
+ledOff	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-RIGHTDIR  LITERAL1
-RIGHTSPEED  LITERAL1
-LEFTDIR LITERAL1
-LEFTSPEED LITERAL1
+RIGHTDIR	LITERAL1
+RIGHTSPEED	LITERAL1
+LEFTDIR	LITERAL1
+LEFTSPEED	LITERAL1


### PR DESCRIPTION
The Arduino IDE currently requires the use of a single true tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords